### PR TITLE
Direct support for 'expires_at' key when constructing AccessToken

### DIFF
--- a/test/oauth2/access_token_test.exs
+++ b/test/oauth2/access_token_test.exs
@@ -43,6 +43,22 @@ defmodule OAuth2.AccessTokenTest do
     assert token.other_params == %{"expires" => "123"}
   end
 
+  test "new with 'expires_at' param" do
+    response =
+      Response.new(
+        %Client{},
+        200,
+        [{"content-type", "application/x-www-form-urlencoded"}],
+        "access_token=abc123&expires_at=123"
+      )
+
+    token = AccessToken.new(response.body)
+    assert token.access_token == "abc123"
+    assert token.expires_at == 123
+    assert token.token_type == "Bearer"
+    assert token.other_params == %{}
+  end
+
   test "new from text/plain content-type" do
     response =
       Response.new(


### PR DESCRIPTION
Currently the `AccessToken.new/1` method does not use the `expires_at` param if it is present in the given map, and only uses `expires_in` or `expires`. It is common to store access tokens in the DB, so when fetching them back and re-constructing the AccessToken struct it should Just Work™️.

This PR changes that to use `expires_at` when it is already present.