### PR TITLE
Remove applications step in install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ An Elixir [OAuth](https://en.wikipedia.org/wiki/OAuth) 2.0 Client Library.
 ```elixir
 # mix.exs
 
-def application do
-  # Add the application to your list of applications.
-  # This will ensure that it will be included in a release.
-  [
-    applications: [:logger, :oauth2]
-  ]
-end
-
 defp deps do
   # Add the dependency
   [


### PR DESCRIPTION
This shouldn't be necessary to explicitly add `oauth2` as an application. Since [Elixir 1.9](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/) releases package up all dependences and their transitive dependencies. `Oauth2` has no application callback, so it shouldn't be needed