### PR TITLE
Allow configurable HTTP Client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,20 @@ end
 Please see the documentation for [OAuth2.Serializer](https://hexdocs.pm/oauth2/OAuth2.Serializer.html)
 for more details.
 
-## Debug mode
+## Configuration
+
+### HTTP client
+
+The default HTTP client for requests is [hackney](https://hex.pm/packages/hackney).
+You can configure it like so:
+
+```elixir
+config :oauth2, http_client: MyCustomClient
+```
+
+It must conform to the `OAuth2.HTTPClient` behaviour.
+
+### Debug mode
 
 Sometimes it's handy to see what's coming back from the response when getting
 a token. You can configure OAuth2 to output the response like so:

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,4 +8,5 @@ config :oauth2,
   # second commit sha
   client_secret: "f715d64092fe81c396ac383e97f8a7eca40e7c89",
   redirect_uri: "http://example.com/auth/callback",
+  http_client: OAuth2.HTTPClient.Hackney,
   request_opts: []

--- a/lib/oauth2/http_client.ex
+++ b/lib/oauth2/http_client.ex
@@ -1,0 +1,12 @@
+defmodule OAuth2.HTTPClient do
+  @callback request(
+              method :: atom(),
+              url :: binary(),
+              headers :: list(),
+              body :: any(),
+              req_opts :: any()
+            ) ::
+              {:ok, any()} | {:ok, integer(), list(), any()} | {:error, any()}
+
+  @callback body(ref :: any()) :: {:ok, binary()} | {:error, any()}
+end

--- a/lib/oauth2/http_client/hackney.ex
+++ b/lib/oauth2/http_client/hackney.ex
@@ -1,0 +1,13 @@
+defmodule OAuth2.HTTPClient.Hackney do
+  @behaviour OAuth2.HTTPClient
+
+  @impl OAuth2.HTTPClient
+  def request(method, url, headers, body, req_opts) do
+    :hackney.request(method, url, headers, body, req_opts)
+  end
+
+  @impl OAuth2.HTTPClient
+  def body(ref) do
+    :hackney.body(ref)
+  end
+end

--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -7,6 +7,7 @@ defmodule OAuth2.Request do
   alias OAuth2.{Client, Error, Response}
 
   @type body :: any
+  @http_client Application.get_env(:oauth2, :http_client, OAuth2.HTTPClient.Hackney)
 
   @doc """
   Makes a request of given type to the given URL using the `OAuth2.AccessToken`.
@@ -33,7 +34,7 @@ defmodule OAuth2.Request do
       """)
     end
 
-    case :hackney.request(method, url, headers, body, req_opts) do
+    case @http_client.request(method, url, headers, body, req_opts) do
       {:ok, ref} when is_reference(ref) ->
         {:ok, ref}
 
@@ -89,7 +90,7 @@ defmodule OAuth2.Request do
   end
 
   defp process_body(client, status, headers, ref) when is_reference(ref) do
-    case :hackney.body(ref) do
+    case @http_client.body(ref) do
       {:ok, body} ->
         process_body(client, status, headers, body)
 


### PR DESCRIPTION
Users can supply their own HTTP Client module to be used by OAuth2.Request:

```elixir
config :oauth2, http_client: MyCustomClient
```

The default is `OAuth2.HTTPClient.Hackney` which conforms to the `OAuth2.HTTPClient` behaviour.

I am writing a Ueberauth strategy using this library, and I want to be able to mock the HTTP client for automated tests. Making it configurable allows that to be possible. There are other legitimate reasons someone might want to provide their own module.