### PR TITLE
fix client params typespec issue

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -37,7 +37,7 @@ defmodule OAuth2.Client do
   @type client_secret :: binary
   @type headers :: [{binary, binary}]
   @type param :: binary | %{binary => param} | [param]
-  @type params :: %{binary => param} | Keyword.t()
+  @type params :: %{binary => param} | Keyword.t() | %{}
   @type redirect_uri :: binary
   @type ref :: reference | nil
   @type request_opts :: Keyword.t()


### PR DESCRIPTION
The PR provides a simple fix to the following type spec issue related to `OAuth2.Client.params()`

The spec for `OAuth2.Client.params()` is currently defined as:

```ex
@type params :: %{binary => param} | Keyword.t()
``` 

However, the default value for  `OAuth2.Client.params()` is an empty map `%{}`:
https://github.com/ueberauth/oauth2/blob/9b46f39503b0cc12a96a3b64e860276176680211/lib/oauth2/client.ex#L72

This gives rise to `Hammox.TypeMatchError` in tests:

```ex
 ** (Hammox.TypeMatchError) 
     1st argument value %OAuth2.Client{authorize_url: "/o/oauth2/v2/auth", client_id: "__REDACTED__", client_secret: "__REDACTED__", headers: [{"content-type", "application/x-www-form-urlencoded"}], params: %{}, redirect_uri: "__REDACTED__", ref: nil, request_opts: [], serializers: %{"application/json" => Jason}, site: "https://accounts.google.com", strategy: Auth.Strategies.Google.Mock, token: nil, token_method: :post, token_url: "__REDACTED__"} does not match 1st parameter's type OAuth2.Client.t().
       Map value %{} for key :params does not match map value type OAuth2.Client.params().
         Value %{} does not match type %{required(binary()) => OAuth2.Client.param()} | Keyword.t().
```

Adding `%{}` to the spec fixes the issue.