### PR TITLE
Add "Accept: application/json" header by default for get_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.1 (2022-06-20)
+
+### Bug fixes
+
+- Fix incorrect Accept header when requesting token
+
 ## v2.0.0 (2019-07-15)
 
 ### Bug fixes (possibly backwards incompatible)

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -478,8 +478,11 @@ defmodule OAuth2.Client do
     |> to_url(:token_url)
   end
 
-  defp token_post_header(%Client{token_method: :post} = client),
-    do: put_header(client, "content-type", "application/x-www-form-urlencoded")
+  defp token_post_header(%Client{token_method: :post} = client) do
+    client
+    |> put_header("content-type", "application/x-www-form-urlencoded")
+    |> put_header("accept", "application/json")
+  end
 
   defp token_post_header(%Client{} = client), do: client
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OAuth2.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/scrogson/oauth2"
-  @version "2.0.0"
+  @version "2.0.1"
 
   def project do
     [


### PR DESCRIPTION
Fixes https://github.com/ueberauth/oauth2/issues/165

See OAuth spec Section 4.1.4. Previously, accept header would be set to
match the content type of the request, which is
application/x-www-form-urlencoded.