### PR TITLE
[docs] Reword `OAuth2.Strategy.AuthCode.authorize_url/2` docs

### DIFF
--- a/lib/oauth2/strategy/auth_code.ex
+++ b/lib/oauth2/strategy/auth_code.ex
@@ -27,8 +27,8 @@ defmodule OAuth2.Strategy.AuthCode do
   use OAuth2.Strategy
 
   @doc """
-  The authorization URL endpoint of the provider.
-  params additional query parameters for the URL
+  Configures the authorization URL endpoint of the provider with additional 
+  query parameters.
   """
   @impl true
   def authorize_url(client, params) do


### PR DESCRIPTION
I find the existing documentation for `OAuth2.Strategy.AuthCode.authorize_url/2` rather vague/confusing.

If my understanding of its responsibility is correct, this is an attempt to improve its documentation.