### PR TITLE
Handle nil response body properly

### DIFF
--- a/lib/oauth2/request.ex
+++ b/lib/oauth2/request.ex
@@ -42,7 +42,8 @@ defmodule OAuth2.Request do
            body: body,
            opts: [adapter: req_opts]
          ) do
-      {:ok, %{status: status, headers: headers, body: body}} when is_binary(body) ->
+      {:ok, %{status: status, headers: headers, body: body}}
+      when is_binary(body) or is_nil(body) ->
         process_body(client, status, headers, body)
 
       {:ok, %{body: ref}} when is_reference(ref) ->
@@ -101,7 +102,7 @@ defmodule OAuth2.Request do
     end
   end
 
-  defp process_body(client, status, headers, body) when is_binary(body) do
+  defp process_body(client, status, headers, body) when is_binary(body) or is_nil(body) do
     resp = Response.new(client, status, headers, body)
 
     case status do

--- a/lib/oauth2/response.ex
+++ b/lib/oauth2/response.ex
@@ -46,6 +46,7 @@ defmodule OAuth2.Response do
     Enum.map(headers, fn {k, v} -> {String.downcase(k), v} end)
   end
 
+  defp decode_response_body(nil, _type, _), do: ""
   defp decode_response_body("", _type, _), do: ""
   defp decode_response_body(" ", _type, _), do: ""
 

--- a/test/oauth2/response_test.exs
+++ b/test/oauth2/response_test.exs
@@ -24,6 +24,11 @@ defmodule OAuth2.ResponseTest do
     assert response.body == "hello"
   end
 
+  test "nil body converts to empty string" do
+    response = Response.new(%OAuth2.Client{}, 204, [], nil)
+    assert response.body == ""
+  end
+
   test "always parse body by serializer if it exists" do
     client = OAuth2.Client.put_serializer(%OAuth2.Client{}, "text/plain", Jason)
     response = Response.new(client, 200, [{"content-type", "text/plain"}], ~S({"hello": "world"}))


### PR DESCRIPTION
It is possible for the body returned by `Tesla.request` to be `nil`. Currently, this raises because there is no matching case. This change adds support for handling a `nil` response from Tesla.

Aside: I attempted to write a client test but, frustratingly, Plug doesn't seem to support building a response with a `nil` body. Happy to add that test if someone knows how to do build the response with Plug. It smells like a bug in Plug to me.