### PR TITLE
remove warnings from mix docs

### DIFF
--- a/lib/oauth2/error.ex
+++ b/lib/oauth2/error.ex
@@ -1,12 +1,11 @@
 defmodule OAuth2.Error do
-  @moduledoc false
-
   @type t :: %__MODULE__{
           reason: binary
         }
 
   defexception [:reason]
 
+  @doc false
   def message(%__MODULE__{reason: :econnrefused}), do: "Connection refused"
   def message(%__MODULE__{reason: reason}) when is_binary(reason), do: reason
   def message(%__MODULE__{reason: reason}), do: inspect(reason)


### PR DESCRIPTION
Currently when running `mix docs` we get [some](https://github.com/ueberauth/oauth2/actions/runs/3824203056#:~:text=client.ex%23L445-,documentation%20references%20type%20%22OAuth2.Error.t()%22%20but%20it%20is%20hidden%20or%20private,-hex%2Dpublish%20/%20Publish) [warnings](https://github.com/ueberauth/oauth2/actions/runs/3824203056/jobs/6506134600#step:3:311). It also happens when referring `OAuth2.Error.t()` from other projects.

```
warning: documentation references type "OAuth2.Error.t()" but it is hidden or private
  lib/oauth2/client.ex:350: OAuth2.Client.refresh_token!/4
```

This PR solves this by making `OAuth2.Error` public in the docs while keeping `OAuth2.Error.message/1` undocumented.