### PR TITLE
correct oauth2 version in changelog explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     defp deps do
       # Add the dependency
       [
-        {:oauth2, "~> 2.0"},
+        {:oauth2, "~> 2.1"},
         {:hackney, "~> 1.18"} # This is the new line you need to add
       ]
     end


### PR DESCRIPTION
I understand it should read "2.1"