### PR TITLE
Update function definiton to say `client`.

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -318,7 +318,7 @@ defmodule OAuth2.Client do
   """
   @spec refresh_token(t, params, headers, Keyword.t()) ::
           {:ok, Client.t()} | {:error, Response.t()} | {:error, Error.t()}
-  def refresh_token(token, params \\ [], headers \\ [], opts \\ [])
+  def refresh_token(client, params \\ [], headers \\ [], opts \\ [])
 
   def refresh_token(%Client{token: %{refresh_token: nil}}, _params, _headers, _opts) do
     {:error, %Error{reason: "Refresh token not available."}}


### PR DESCRIPTION
Fixes the attribute variable name to be more explicit so that we expect the `Client` value schema type.

When I was browsing the docs I was confused to see "token" here, but I think this is mostly a typo.

<img width="1032" alt="Screen Shot 2023-07-12 at 2 28 04 PM" src="https://github.com/ueberauth/oauth2/assets/52168/e5e136e9-ae57-43ab-babc-1fdf252fce0f">
