### PR TITLE
Redact sensitive struct fields on inspect

### DIFF
--- a/lib/oauth2/access_token.ex
+++ b/lib/oauth2/access_token.ex
@@ -29,6 +29,7 @@ defmodule OAuth2.AccessToken do
           other_params: other_params
         }
 
+  @derive {Inspect, except: [:access_token, :refresh_token]}
   defstruct access_token: "",
             refresh_token: nil,
             expires_at: nil,

--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -65,6 +65,7 @@ defmodule OAuth2.Client do
           token_url: token_url
         }
 
+  @derive {Inspect, except: [:client_secret]}
   defstruct authorize_url: "/oauth/authorize",
             client_id: "",
             client_secret: "",


### PR DESCRIPTION
Hi,

Thanks for this great library.

Noticed these fields end up on our app's logs and/or error tracking reports in cases like e.g. `MatchError: no match of right hand side value: %OAuth2.Client{..., client_secret: "<secret>", ...}` when having match errors when doing stuff like

```elixir
%{
  ...
} = oauth2_client
````

We temporarily fixed this on our app's end by writing

```elixir
defimpl Inspect, for: OAuth2.Client do
  def inspect(%OAuth2.Client{} = client, opts) do
    client
    |> Map.replace(:client_secret, "[REDACTED]")
    |> Inspect.Any.inspect(opts)
  end
end

defimpl Inspect, for: OAuth2.AccessToken do
  def inspect(%OAuth2.AccessToken{} = client, opts) do
    client
    |> Map.replace(:access_token, "[REDACTED]")
    |> Map.replace(:refresh_token, "[REDACTED]")
    |> Inspect.Any.inspect(opts)
  end
end
```

But maybe you wanted to consider adding it to the package?

Thanks.