### PR TITLE
Eliminate warnings in modern Elixir releases

### DIFF
--- a/lib/oauth2/client.ex
+++ b/lib/oauth2/client.ex
@@ -223,7 +223,7 @@ defmodule OAuth2.Client do
   @spec put_serializer(t, binary, atom) :: t
   def put_serializer(%Client{serializers: serializers} = client, mime, module)
       when is_binary(mime) and is_atom(module) do
-    %Client{client | serializers: Map.put(serializers, mime, module)}
+    %{client | serializers: Map.put(serializers, mime, module)}
   end
 
   @doc """
@@ -238,7 +238,7 @@ defmodule OAuth2.Client do
   """
   @spec delete_serializer(t, binary) :: t
   def delete_serializer(%Client{serializers: serializers} = client, mime) do
-    %Client{client | serializers: Map.delete(serializers, mime)}
+    %{client | serializers: Map.delete(serializers, mime)}
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,8 @@ defmodule OAuth2.Mixfile do
   def project do
     maybe_cli =
       if Version.compare(System.version(), "1.14.5") == :gt do
+        []
+      else
         [
           preferred_cli_env: [
             coveralls: :test,
@@ -15,8 +17,6 @@ defmodule OAuth2.Mixfile do
             docs: :dev
           ]
         ]
-      else
-        []
       end
 
     [

--- a/mix.exs
+++ b/mix.exs
@@ -16,12 +16,6 @@ defmodule OAuth2.Mixfile do
       docs: docs(),
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.html": :test,
-        docs: :dev
-      ],
       dialyzer: dialyzer()
     ]
   end
@@ -78,6 +72,17 @@ defmodule OAuth2.Mixfile do
         Changelog: "https://hexdocs.pm/oauth2/changelog.html",
         GitHub: @source_url
       }
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.html": :test,
+        docs: :dev
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,20 @@ defmodule OAuth2.Mixfile do
   @version "2.1.0"
 
   def project do
+    maybe_cli =
+      if Version.compare(System.version(), "1.14.5") == :gt do
+        [
+          preferred_cli_env: [
+            coveralls: :test,
+            "coveralls.detail": :test,
+            "coveralls.html": :test,
+            docs: :dev
+          ]
+        ]
+      else
+        []
+      end
+
     [
       app: :oauth2,
       name: "OAuth2",
@@ -17,7 +31,7 @@ defmodule OAuth2.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       dialyzer: dialyzer()
-    ]
+    ] ++ maybe_cli
   end
 
   def application do
@@ -75,15 +89,17 @@ defmodule OAuth2.Mixfile do
     ]
   end
 
-  def cli do
-    [
-      preferred_envs: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.html": :test,
-        docs: :dev
+  if Version.compare(System.version(), "1.14.5") == :gt do
+    def cli do
+      [
+        preferred_envs: [
+          coveralls: :test,
+          "coveralls.detail": :test,
+          "coveralls.html": :test,
+          docs: :dev
+        ]
       ]
-    ]
+    end
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
This tiny PR eliminates warnings in upcoming 1.19 andalso makes `:preferred_cli_env` in `mix.exs` gracefully changed to modern `cli/1` when applicable based on `System.version/0`. 